### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,7 +2,7 @@ class ProductsController < ApplicationController
   before_action :authenticate_user!, except: :index
   
   def index
-    @product = Product.all
+    @products = Product.order("created_at DESC")
   end
 
   def new

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,6 +2,7 @@ class ProductsController < ApplicationController
   before_action :authenticate_user!, except: :index
   
   def index
+    @product = Product.all
   end
 
   def new

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -158,23 +158,25 @@
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
-      <%# <li class='list'> %>
-        <%# <%= link_to '#' do %>
-        <%# <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-        <%# <div class='item-info'> %>
-          <%# <h3 class='item-name'> %>
-            <%# 商品を出品してね！ %>
-          <%# </h3> %>
-          <%# <div class='item-price'> %>
-            <%# <span>99999999円<br>(税込み)</span> %>
-            <%# <div class='star-btn'> %>
-              <%# <%= image_tag "star.png", class:"star-icon" %>
-              <%# <span class='star-count'>0</span> %>
-            <%# </div> %>
-          <%# </div> %>
-        <%# </div> %>
-        <%# <% end %>
-      <%# </li> %>
+      <% unless @products.exists? %>
+      <li class='list'>
+        <%= link_to '#' do %>
+        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img"%>
+        <div class='item-info'>
+          <h3 class='item-name'>
+            商品を出品してね！
+          </h3>
+          <div class='item-price'>
+            <span>99999999円<br>(税込み)</span>
+            <div class='star-btn'>
+              <%= image_tag "star.png", class:"star-icon" %>
+              <span class='star-count'>0</span>
+            </div>
+          </div>
+        </div>
+         <% end %>
+         <% end %>
+       </li> 
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# /商品がない場合のダミー %>
     </ul>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -127,7 +127,7 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <% @product.each do |product|%>
+      <% @products.each do |product|%>
       <li class='list'>
         <%= link_to ""  %>
         <div class='item-img-content'>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -158,7 +158,7 @@
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
-      <% unless @products.exists? %>
+      <% if @products.blank? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img"%>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -127,11 +127,11 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
       <% @product.each do |product|%>
+      <li class='list'>
         <%= link_to ""  %>
         <div class='item-img-content'>
-          <%= image_tag(product.image, class: "item-img") if product.image.attached? %>
+          <%= image_tag(product.image.variant(resize:"300X300"), class: "item-img") if product.image.attached? %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <%# <div class='sold-out'>
@@ -160,7 +160,7 @@
       <%# 商品がある場合は表示されないようにしましょう %>
       <%# <li class='list'> %>
         <%# <%= link_to '#' do %>
-        <%# <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %> %>
+        <%# <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
         <%# <div class='item-info'> %>
           <%# <h3 class='item-name'> %>
             <%# 商品を出品してね！ %>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -128,23 +128,24 @@
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
-        <%= link_to "#" do %>
+      <% @product.each do |product|%>
+        <%= link_to ""  %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag(product.image, class: "item-img") if product.image.attached? %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
+          <%# <div class='sold-out'>
             <span>Sold Out!!</span>
-          </div>
+          </div> %>
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= product.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= product.price %>円<br><%= product.delivery_fee.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -157,23 +158,23 @@
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
+      <%# <li class='list'> %>
+        <%# <%= link_to '#' do %>
+        <%# <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %> %>
+        <%# <div class='item-info'> %>
+          <%# <h3 class='item-name'> %>
+            <%# 商品を出品してね！ %>
+          <%# </h3> %>
+          <%# <div class='item-price'> %>
+            <%# <span>99999999円<br>(税込み)</span> %>
+            <%# <div class='star-btn'> %>
+              <%# <%= image_tag "star.png", class:"star-icon" %>
+              <%# <span class='star-count'>0</span> %>
+            <%# </div> %>
+          <%# </div> %>
+        <%# </div> %>
+        <%# <% end %>
+      <%# </li> %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# /商品がない場合のダミー %>
     </ul>

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -1,15 +1,15 @@
 FactoryBot.define do
   factory :product do
-    name                    { Faker::Games::Zelda.item }
-    description             { Faker::Lorem.sentence }
-    price                   { Faker::Number.between(from: 300, to: 9_999_999) }
+    name                    { 'モンスターボール'}
+    description             { 'ポケモンを気軽にゲットし、連れ歩ける大発明！' }
+    price                   { '1000000' }
+    category_id             {4}
+    status_id               {2}
+    shipment_prefecture_id  {2}
+    date_of_shipment_id     {2}
+    delivery_fee_id         {2}
 
     association :user
-    association :category
-    association :status
-    association :shipment_prefecture
-    association :date_of_shipment
-    association :delivery_fee
 
     after(:build) do |product|
       product.image.attach(io: File.open('public/images/zel3.png'), filename: 'zel3.png')


### PR DESCRIPTION
# what
トップページへの商品の一覧表示機能

# why
ユーザーがアプリへ投稿されている商品を閲覧することができるようにするため

# 機能の様子
- 商品を出品すると一覧に表示される様子。また、新しいものは一番上に来ている様子
https://gyazo.com/6393e9b732c6e67708606f11ac36f754
- ログアウト状態のユーザーでも商品の一覧は閲覧できている様子
https://gyazo.com/5b7138e769e6ac60c91109c2f9dc6f88

SOLDOUTの表示は商品の購入機能が未実装のため今回は実装しておりません